### PR TITLE
Various fixes and improvements

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,5 @@
-BACKEND_URL="https://example.com"
+BACKEND_URL="http://localhost:9001"
+WEBSOCKET_BACKEND_URL="ws://localhost:9001/v2/ws"
 PORT=8387
 DB_PATH=requests.db
 CA_CERT="-----BEGIN CERTIFICATE-----

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+
+swapproxy
+requests.db

--- a/config.go
+++ b/config.go
@@ -57,18 +57,19 @@ func LoadConfig() (*Config, error) {
 	}
 
 	caCertPEM := os.Getenv("CA_CERT")
-	if caCertPEM == "" {
-		return nil, fmt.Errorf("CA_CERT environment variable is required")
-	}
+	var caCert *x509.Certificate
+	if caCertPEM != "" {
+		block, err := base64.StdEncoding.DecodeString(caCertPEM)
+		if err != nil {
+			return nil, fmt.Errorf("Could not decode certificate base64 body: %w", err)
+		}
 
-	block, err := base64.StdEncoding.DecodeString(caCertPEM)
-	if err != nil {
-		return nil, fmt.Errorf("Could not decode certificate base64 body: %w", err)
-	}
-
-	caCert, err := x509.ParseCertificate(block)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+		caCert, err = x509.ParseCertificate(block)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+		}
+	} else {
+		log.Println("Warning: CA_CERT environment variable not provided. Running without API key validation.")
 	}
 
 	httpAdditionalParamsStr := os.Getenv("HTTP_ADDITIONAL_PARAMETERS")

--- a/config.go
+++ b/config.go
@@ -56,9 +56,13 @@ func LoadConfig() (*Config, error) {
 		dbPath = "requests.db"
 	}
 
-	caCertPEM := os.Getenv("CA_CERT")
 	var caCert *x509.Certificate
-	if caCertPEM != "" {
+	if os.Getenv("DANGEROUS_NO_CA_CERT") != "YES" {
+		caCertPEM := os.Getenv("CA_CERT")
+		if caCertPEM == "" {
+			return nil, fmt.Errorf("CA_CERT environment variable is required")
+		}
+
 		block, err := base64.StdEncoding.DecodeString(caCertPEM)
 		if err != nil {
 			return nil, fmt.Errorf("Could not decode certificate base64 body: %w", err)
@@ -68,8 +72,6 @@ func LoadConfig() (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
 		}
-	} else {
-		log.Println("Warning: CA_CERT environment variable not provided. Running without API key validation.")
 	}
 
 	httpAdditionalParamsStr := os.Getenv("HTTP_ADDITIONAL_PARAMETERS")

--- a/database.go
+++ b/database.go
@@ -162,11 +162,13 @@ func NewReverseProxy(config *Config, db *sql.DB) *httputil.ReverseProxy {
 		// Remove Authorization header before forwarding
 		req.Header.Del("Authorization")
 
-		if apiKey == "" || !validateAPIKey(config.CACert, apiKey) {
-			log.Printf("API key validation failed")
-			ctx = context.WithValue(req.Context(), "unauthorized", true)
-			*req = *req.WithContext(ctx)
-			return
+		if config.CACert != nil {
+			if apiKey == "" || !validateAPIKey(config.CACert, apiKey) {
+				log.Printf("API key validation failed")
+				ctx = context.WithValue(req.Context(), "unauthorized", true)
+				*req = *req.WithContext(ctx)
+				return
+			}
 		}
 
 		ctx = context.WithValue(req.Context(), "api_key", apiKey)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	// Set up WebSocket proxy
 	wsProxy := NewWebSocketProxy(config.WebSocketBackendURL.String(), config)
 	wsProxy.Start()
-	http.HandleFunc("/ws", wsProxy.HandleWebSocket)
+	http.HandleFunc("/v2/ws", wsProxy.HandleWebSocket)
 
 	// Set up HTTP handler
 	http.Handle("/", proxy)

--- a/websocket.go
+++ b/websocket.go
@@ -80,6 +80,7 @@ func (p *WebSocketProxy) HandleWebSocket(w http.ResponseWriter, r *http.Request)
 		log.Printf("Extracted API key (length): %d", len(apiKey))
 	}
 
+	if p.config.CACert != nil {
 	if apiKey == "" || !validateAPIKey(p.config.CACert, apiKey) {
 		log.Printf("WebSocket connection rejected: invalid API key")
 		// Send error message and close connection
@@ -91,6 +92,7 @@ func (p *WebSocketProxy) HandleWebSocket(w http.ResponseWriter, r *http.Request)
 		conn.Write(context.Background(), websocket.MessageText, messageBytes)
 		conn.CloseNow()
 		return
+	}
 	}
 
 	// Set a read timeout (e.g., 30 seconds)

--- a/websocket.go
+++ b/websocket.go
@@ -81,18 +81,18 @@ func (p *WebSocketProxy) HandleWebSocket(w http.ResponseWriter, r *http.Request)
 	}
 
 	if p.config.CACert != nil {
-	if apiKey == "" || !validateAPIKey(p.config.CACert, apiKey) {
-		log.Printf("WebSocket connection rejected: invalid API key")
-		// Send error message and close connection
-		errMsg := map[string]any{
-			"event": "error",
-			"error": "invalid API key",
+		if apiKey == "" || !validateAPIKey(p.config.CACert, apiKey) {
+			log.Printf("WebSocket connection rejected: invalid API key")
+			// Send error message and close connection
+			errMsg := map[string]any{
+				"event": "error",
+				"error": "invalid API key",
+			}
+			messageBytes, _ := json.Marshal(errMsg)
+			conn.Write(context.Background(), websocket.MessageText, messageBytes)
+			conn.CloseNow()
+			return
 		}
-		messageBytes, _ := json.Marshal(errMsg)
-		conn.Write(context.Background(), websocket.MessageText, messageBytes)
-		conn.CloseNow()
-		return
-	}
 	}
 
 	// Set a read timeout (e.g., 30 seconds)
@@ -499,9 +499,10 @@ func (p *WebSocketProxy) Start() {
 			for client, updates := range clientUpdates {
 				// Create a single notification message for the client
 				notification := map[string]any{
-					"event":   msg["event"],
-					"channel": msg["channel"],
-					"args":    updates,
+					"event":     msg["event"],
+					"channel":   msg["channel"],
+					"args":      updates,
+					"timestamp": strconv.FormatInt(time.Now().Unix(), 10),
 				}
 
 				// Marshal the message into JSON ([]byte)


### PR DESCRIPTION
This PR:

- Sets the env example urls to the ones from https://github.com/BoltzExchange/regtest
- Makes API key validation optional (to facilitate running a regtest instance)
- Fixes the websocket route to match boltz (`/v2/ws`)
- Adds a timestamp to the notification payload (the SDK was failing to parse the message)

With these changes, I was able to successfully receive using receive swaps both using invoices and offers, indicating that at least in a very basic case, the proxy is working as expected.