### PR TITLE
Use ws protocol header for auth

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -73,7 +73,7 @@ func (p *WebSocketProxy) HandleWebSocket(w http.ResponseWriter, r *http.Request)
 	}
 	defer conn.CloseNow()
 
-	authHeader := r.Header.Get("Authorization")
+	authHeader := r.Header.Get("Sec-WebSocket-Protocol")
 	apiKey := ""
 	if strings.HasPrefix(authHeader, "Bearer ") {
 		apiKey = strings.TrimPrefix(authHeader, "Bearer ")


### PR DESCRIPTION
This PR proposes using the ws protocols header to circumvent the impossibility of setting the `Authorization` header in browsers. This is a misuse of the header but I haven't seen any significant issues/risks with the approach. 

TODO:

- [ ] Test