### PR TITLE
Always set extraFee id

### DIFF
--- a/http.go
+++ b/http.go
@@ -69,8 +69,8 @@ func validateAPIKey(cert *x509.Certificate, apiKeyStr string) bool {
 }
 
 type ExtraFees struct {
-	ID         string  `json:"id"`
-	Percentage float64 `json:"percentage"`
+	ID         string   `json:"id"`
+	Percentage *float64 `json:"percentage,omitempty"`
 }
 
 func addRequestExtraFees(body []byte, extraFee Fee) ([]byte, error) {
@@ -79,10 +79,16 @@ func addRequestExtraFees(body []byte, extraFee Fee) ([]byte, error) {
 		return nil, fmt.Errorf("error unmarshaling JSON: %w", err)
 	}
 
-	jsonBody["extraFees"] = ExtraFees{
-		ID:         strconv.Itoa(extraFee.PartnerID),
-		Percentage: extraFee.FeePercentage,
+	extraFees := ExtraFees{
+		ID: strconv.Itoa(extraFee.PartnerID),
 	}
+
+	// Set percentage if it exists and is greater than 0
+	if extraFee.FeePercentage != nil && *extraFee.FeePercentage > 0 {
+		extraFees.Percentage = extraFee.FeePercentage
+	}
+
+	jsonBody["extraFees"] = extraFees
 
 	modifiedBody, err := json.Marshal(jsonBody)
 	if err != nil {
@@ -219,7 +225,7 @@ func NewReverseProxy(config *Config, sqlite *sql.DB, postgres *Database) *httput
 						log.Printf("Error reading request body: %v", err)
 					} else {
 						extraFee := getExtraFee(postgres, apiKey)
-						if extraFee != nil && extraFee.FeePercentage > 0 {
+						if extraFee != nil {
 							modifiedBody, err := addRequestExtraFees(reqBody, *extraFee)
 							if err != nil {
 								log.Printf("Error modifying request body: %v", err)
@@ -227,6 +233,8 @@ func NewReverseProxy(config *Config, sqlite *sql.DB, postgres *Database) *httput
 								reqBody = modifiedBody
 								log.Printf("Modified request body for %s", originalPath)
 							}
+						} else {
+							log.Printf("No partner id found for api key %s", apiKey)
 						}
 						req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 						req.ContentLength = int64(len(reqBody))
@@ -294,8 +302,8 @@ func NewReverseProxy(config *Config, sqlite *sql.DB, postgres *Database) *httput
 					} else {
 						apiKey, _ := res.Request.Context().Value("api_key").(string)
 						extraFee := getExtraFee(postgres, apiKey)
-						if extraFee != nil && extraFee.FeePercentage > 0 {
-							modifiedBody := modifyResponsePercentages(jsonBody, extraFee.FeePercentage)
+						if extraFee != nil && extraFee.FeePercentage != nil && *extraFee.FeePercentage > 0 {
+							modifiedBody := modifyResponsePercentages(jsonBody, *extraFee.FeePercentage)
 							modifiedJSON, err := json.Marshal(modifiedBody)
 							if err != nil {
 								log.Printf("Error marshaling modified response JSON: %v", err)

--- a/postgres.go
+++ b/postgres.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -37,7 +38,7 @@ func (db *Database) Close() {
 
 type Fee struct {
 	PartnerID     int
-	FeePercentage float64
+	FeePercentage *float64
 }
 
 type FeeModel struct {
@@ -51,17 +52,25 @@ func NewFeeModel(db *pgxpool.Pool) *FeeModel {
 func (m *FeeModel) GetByPartnerApiKey(api_key string) (*Fee, error) {
 	query := `SELECT p.id, fs.fee_percentage
 				FROM partners p
-				JOIN fee_settings fs ON p.id = fs.partner_id
+				LEFT JOIN fee_settings fs ON p.id = fs.partner_id
 				WHERE p.api_key = $1;`
 	row := m.DB.QueryRow(context.Background(), query, api_key)
 
 	var fee Fee
-	err := row.Scan(&fee.PartnerID, &fee.FeePercentage)
+	var feePercentage sql.NullFloat64
+	err := row.Scan(&fee.PartnerID, &feePercentage)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
+	}
+
+	// Set FeePercentage to nil if the value is NULL in the database
+	if feePercentage.Valid {
+		fee.FeePercentage = &feePercentage.Float64
+	} else {
+		fee.FeePercentage = nil
 	}
 
 	return &fee, nil


### PR DESCRIPTION
This updates the proxy to take advantage of https://github.com/BoltzExchange/boltz-backend/pull/1060.

The id from extra fees is always set, even when there's no defined extra fee. This allows for the later retrieval of per-partner general statistics, such as total swapped volume.

TODO:

- [x] Test (waiting for boltz backend changes to be deployed)