### PR TITLE
fix: accept WebSocket connections from any origin

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -66,7 +66,9 @@ func (p *WebSocketProxy) connectToUpstream() error {
 }
 
 func (p *WebSocketProxy) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
-	conn, err := websocket.Accept(w, r, nil)
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		OriginPatterns: []string{"*"},
+	})
 	if err != nil {
 		log.Printf("WebSocket upgrade error: %v", err)
 		return


### PR DESCRIPTION
WASM SDK clients connect from unpredictable third-party origins.
Use `OriginPatterns` wildcard instead of rejecting cross-origin WebSocket upgrades.

Security is maintained by the existing certificate-based API key authentication (`Bearer` token on HTTP, first-message `apikey` on WS), which is independent of the Origin header.

Needed for WASM regtest support in breez/breez-sdk-liquid#1094.